### PR TITLE
Give clients control over MIME types

### DIFF
--- a/Sources/Core/DAVRequests.h
+++ b/Sources/Core/DAVRequests.h
@@ -41,10 +41,12 @@
 
 @interface DAVPutRequest : DAVRequest {
   @private
-	NSData *_pdata;
+	NSData      *_pdata;
+    NSString    *_MIMEType;
 }
 
 // Pass - [NSData dataWithContentsOfFile:] to upload a local file
 @property (retain) NSData *data;
+@property(nonatomic, copy) NSString *dataMIMEType;  // defaults to application/octet-stream
 
 @end

--- a/Sources/Core/DAVRequests.m
+++ b/Sources/Core/DAVRequests.m
@@ -139,7 +139,17 @@
 
 @implementation DAVPutRequest
 
+- (id)initWithPath:(NSString *)path;
+{
+    if (self = [super initWithPath:path])
+    {
+        _MIMEType = @"application/octet-stream";
+    }
+    return self;
+}
+
 @synthesize data = _pdata;
+@synthesize dataMIMEType = _MIMEType;
 
 - (NSURLRequest *)request {
 	NSParameterAssert(_pdata != nil);
@@ -147,15 +157,18 @@
 	NSString *len = [NSString stringWithFormat:@"%d", [_pdata length]];
 	
 	NSMutableURLRequest *req = [self newRequestWithPath:self.path method:@"PUT"];
-	[req setValue:@"application/octet-stream" forHTTPHeaderField:@"Content-Type"];
+	[req setValue:[self dataMIMEType] forHTTPHeaderField:@"Content-Type"];
 	[req setValue:len forHTTPHeaderField:@"Content-Length"];
     [req setHTTPBody:_pdata];
 	
 	return [req autorelease];
 }
 
-- (void)dealloc {
+- (void)dealloc
+{
 	[_pdata release];
+    [_MIMEType release];
+    
 	[super dealloc];
 }
 


### PR DESCRIPTION
We found that the default behaviour of marking everything as `application/octet-stream` is no good for publishing a website since that gets passed back to web browsers which often choose to download the content, rather than display as HTML.
