### PR TITLE
Implement DAVPutStreamRequest

### DIFF
--- a/Sources/Core/DAVRequests.h
+++ b/Sources/Core/DAVRequests.h
@@ -50,3 +50,15 @@
 @property (copy) NSString *dataMIMEType; // defaults to application/octet-stream
 
 @end
+
+@interface DAVPutStreamRequest : DAVRequest {
+    @private
+    NSString *_pfilepath;
+    NSString *_MIMEtype;
+}
+
+// Pass - Path to local file
+@property (strong) NSString *filepath;
+@property (copy) NSString *dataMIMEType; // defaults to application/octet-stream
+
+@end

--- a/Sources/Core/DAVRequests.m
+++ b/Sources/Core/DAVRequests.m
@@ -156,3 +156,39 @@
 }
 
 @end
+
+@implementation DAVPutStreamRequest
+
+- (id)initWithPath:(NSString *)aPath {
+	if ((self = [super initWithPath:aPath])) {
+		self.dataMIMEType = @"application/octet-stream";
+	}
+	return self;
+}
+
+@synthesize filepath = _pfilepath;
+@synthesize dataMIMEType = _MIMEType;
+
+- (NSInputStream *)connection:(NSURLConnection *)connection needNewBodyStream:(NSURLRequest *)req {
+    
+    return [NSInputStream inputStreamWithFileAtPath:_pfilepath];
+}
+
+- (NSURLRequest *)request {
+	NSParameterAssert(_pfilepath != nil);
+	
+    NSError *error = nil;
+    NSDictionary *attrs = [[NSFileManager defaultManager] attributesOfItemAtPath:_pfilepath
+                                                                            error:&error];
+    if (!attrs) return nil;
+    
+	NSString *len = [NSString stringWithFormat:@"%lld", attrs.fileSize];
+	NSMutableURLRequest *req = [self newRequestWithPath:self.path method:@"PUT"];
+	[req setValue:[self dataMIMEType] forHTTPHeaderField:@"Content-Type"];
+	[req setValue:len forHTTPHeaderField:@"Content-Length"];
+    [req setHTTPBodyStream:[NSInputStream inputStreamWithFileAtPath:_pfilepath]];
+	
+	return req;
+}
+
+@end


### PR DESCRIPTION
DAVStreamRequest for NSInputStream request, so that large files can be send without mapping them to RAM fully (which can cause OOM).

Not tested, but should work. I already implemented subclasses with block callbacks and this basically uses the same code, without the added bits.
